### PR TITLE
Fixed Makefile to correctly locate support/input.yaml, clarified README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,13 @@ CHECKK8S="k8s.sh"
 CHECKGKE="gke.sh"
 CHECKAKS="aks.sh"
 CHECKEKS="eks.sh"
+MKITBASEDIR=$(abspath $(dir ./))
 
 NDEF = $(if $(value $(1)),,$(error $(1) not set))
 
 DOCKERBUILD=docker build -t $(IMAGEREPO):latest .
 
-COMMAND=docker run --rm -it -p8000:8000 -v "$(PWD)/support/input.yaml":$(WORKDIR)/input.yaml
+COMMAND=docker run --rm -it -p8000:8000 -v "$(MKITBASEDIR)/support/input.yaml":$(WORKDIR)/input.yaml
 
 GKEDEVMOUNT=-v $(LOCALDIR)/inspec-profile-gke:$(HOMEDIR)/profiles/inspec-profile-gke \
   -v $(LOCALDIR)/inspec-profile-k8s:$(HOMEDIR)/profiles/inspec-profile-k8s

--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ The **MKIT** web UI ([http://localhost:8000](http://localhost:8000)) shows all o
 
 ## Quick Start
 
-1. Clone this repository to your Linux / macOS / WSL2 system.
-2. See the [section](#building-the-docker-image-manually) on building the image manually, if desired.
-3. Ensure you have the permissions to `get/list/describe` your cluster via the native APIs and you have Kubernetes `cluster-admin` or the `view` `ClusterRole` bound to your current account.
-4. Run the tool for your use case:
+1. Install Docker, if you have not done so already.
+2. Clone this repository to your Linux / macOS / WSL2 system.
+3. See the [section](#building-the-docker-image-manually) on building the image manually, if desired.
+4. Ensure you have the permissions to `get/list/describe` your cluster via the native APIs and you have Kubernetes `cluster-admin` or the `view` `ClusterRole` bound to your current account.
+5. Ensure that all commands after this step are run in the context of a user with access to run Docker containers (e.g. `root`). Do not use `sudo`, as this will not preserve the authentication-related environment variables.
+6. Run the tool for your use case:
 
 **AKS**
 


### PR DESCRIPTION
The existing Makefile references an environment variable named `PWD` that's not present on all systems, and was causing the `make` command to fail with the following error on Kali Linux:

```
docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:76: mounting "/support/input.yaml" to rootfs at "/home/node/audit/input.yaml" caused: mount through procfd: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type.
```

I added new `MKITBASEDIR` variable that's explicitly set to the directory where the `make` command is being run so that the YAML file would be mounted correctly.

I also clarified the steps in the "Quick Start" section of `README.md` to make it clear that the commands need to be run in the context of a privileged user. i.e. on Linux, if you are starting out as a standard user and try to export the auth-related environment variables, then run the `make` command using `sudo`, it will fail. For AWS, since `mkit` references the AWS CLI profile name, it's easiest to just `sudo su`, set up the necessary AWS CLI profile settings as `root`, export the environment variables, and run the `make` command all in that `su`'d shell.